### PR TITLE
Update pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -751,7 +751,7 @@
         <dependency>
             <groupId>org.apache.httpcomponents.core5</groupId>
             <artifactId>httpcore5</artifactId>
-            <version>5.1.5</version>
+            <version>5.1.6</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
This pull request includes a minor update to the `pom.xml` file. The version of the `httpcore5` dependency from `org.apache.httpcomponents.core5` group has been updated from `5.1.5` to `5.1.6`.